### PR TITLE
Refactor PoC into CLI recorder with CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.16)
+project(dng_recorder)
+
+set(CMAKE_CXX_STANDARD 17)
+
+add_executable(dng-recorder
+    src/main.cpp
+    src/raw_recorder.cpp
+)
+
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(LIBCAMERA REQUIRED libcamera)
+target_include_directories(dng-recorder PRIVATE ${LIBCAMERA_INCLUDE_DIRS})
+target_link_libraries(dng-recorder PRIVATE ${LIBCAMERA_LIBRARIES})
+
+pkg_check_modules(GSTREAMER gstreamer-1.0 gstreamer-app-1.0)
+if(GSTREAMER_FOUND)
+    target_include_directories(dng-recorder PRIVATE ${GSTREAMER_INCLUDE_DIRS})
+    target_link_libraries(dng-recorder PRIVATE ${GSTREAMER_LIBRARIES})
+else()
+    target_compile_definitions(dng-recorder PRIVATE NO_GST)
+endif()
+
+find_package(TIFF REQUIRED)
+target_link_libraries(dng-recorder PRIVATE TIFF::TIFF pthread)
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,34 @@
 # dng-video
+
+Prototype raw video recorder using libcamera. The recorder now exposes a
+command line interface compatible with common `rpicam-vid` parameters.
+
+## Building
+
+```sh
+cmake -S . -B build
+cmake --build build
+```
+
+## Usage
+
+```sh
+./build/dng-recorder [options] [output_directory]
+```
+
+Options:
+
+- `--fps <fps>`               target frames per second
+- `--shutter <microsec>`      exposure time in microseconds
+- `--gain <gain>`             analogue gain
+- `--ae <0|1>`                disable auto-exposure if set to 1
+- `--awb <0|1>`               disable auto white balance if set to 1
+- `--preview`                 enable hardware preview stream
+- `--preview-size WxH`        preview dimensions
+- `--preview-sink <sink>`     preview sink (`gl` or `kmssink`)
+- `--preview-every N`         push every Nth preview frame
+- `--size WxH`                RAW stream size
+
+The legacy environment variable overrides from the original proof of
+concept remain available.
+

--- a/include/raw_recorder.h
+++ b/include/raw_recorder.h
@@ -1,0 +1,4 @@
+#pragma once
+
+int run_raw_recorder(int argc, char **argv);
+

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,47 @@
+#include "raw_recorder.h"
+
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <string>
+#include <vector>
+
+int main(int argc, char **argv) {
+    std::string outDir = "./frames";
+
+    for (int i = 1; i < argc; ++i) {
+        std::string arg = argv[i];
+        if (arg == "--fps" && i + 1 < argc) {
+            setenv("FPS", argv[++i], 1);
+        } else if (arg == "--shutter" && i + 1 < argc) {
+            setenv("EXP_US", argv[++i], 1);
+        } else if (arg == "--gain" && i + 1 < argc) {
+            setenv("AGAIN", argv[++i], 1);
+        } else if (arg == "--ae" && i + 1 < argc) {
+            setenv("AE", argv[++i], 1);
+        } else if (arg == "--awb" && i + 1 < argc) {
+            setenv("AWB", argv[++i], 1);
+        } else if (arg == "--preview") {
+            setenv("PREVIEW", "1", 1);
+        } else if (arg == "--preview-size" && i + 1 < argc) {
+            setenv("PREVIEW_SIZE", argv[++i], 1);
+        } else if (arg == "--preview-sink" && i + 1 < argc) {
+            setenv("PREVIEW_SINK", argv[++i], 1);
+        } else if (arg == "--preview-every" && i + 1 < argc) {
+            setenv("PREVIEW_EVERY", argv[++i], 1);
+        } else if (arg == "--size" && i + 1 < argc) {
+            setenv("SIZE", argv[++i], 1);
+        } else if (arg.rfind("--", 0) == 0) {
+            std::cerr << "Unknown option: " << arg << std::endl;
+            return 1;
+        } else {
+            outDir = arg;
+        }
+    }
+
+    std::vector<char *> args;
+    args.push_back(argv[0]);
+    args.push_back(const_cast<char *>(outDir.c_str()));
+    return run_raw_recorder(static_cast<int>(args.size()), args.data());
+}
+

--- a/src/raw_recorder.cpp
+++ b/src/raw_recorder.cpp
@@ -632,7 +632,7 @@ static StreamRole choose_role_from_env_or_flag()
 #endif
 }
 
-int main(int argc, char **argv)
+int run_raw_recorder(int argc, char **argv)
 {
     std::signal(SIGINT, sigint_handler);
     std::signal(SIGTERM, sigint_handler);


### PR DESCRIPTION
## Summary
- add CMake-based build system for libcamera raw recorder
- expose run_raw_recorder entry point and add CLI front-end for rpicam-vid style args
- document build and usage in README

## Testing
- `cmake -S . -B build` *(fails: Package 'libcamera' not found)*
- `apt-get update` *(fails: repositories not signed / 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c34a1d83688327b35c92ab4f44f5b8