### PR TITLE
Add CLI help and version options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
-project(dng_recorder)
+project(dng_recorder VERSION 0.1.0)
 
 set(CMAKE_CXX_STANDARD 17)
 
@@ -12,6 +12,10 @@ find_package(PkgConfig REQUIRED)
 pkg_check_modules(LIBCAMERA REQUIRED libcamera)
 target_include_directories(dng-recorder PRIVATE ${LIBCAMERA_INCLUDE_DIRS})
 target_link_libraries(dng-recorder PRIVATE ${LIBCAMERA_LIBRARIES})
+
+target_compile_definitions(dng-recorder PRIVATE
+    DNG_RECORDER_VERSION="${PROJECT_VERSION}"
+)
 
 pkg_check_modules(GSTREAMER gstreamer-1.0 gstreamer-app-1.0)
 if(GSTREAMER_FOUND)

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ cmake --build build
 ./build/dng-recorder [options] [output_directory]
 ```
 
+Run `./build/dng-recorder --help` to see a full list of options or `--version`
+to print the application's version.
+
 Options:
 
 - `--fps <fps>`               target frames per second
@@ -28,6 +31,8 @@ Options:
 - `--preview-sink <sink>`     preview sink (`gl` or `kmssink`)
 - `--preview-every N`         push every Nth preview frame
 - `--size WxH`                RAW stream size
+- `--help, -h`                display help and exit
+- `--version, -v`             show program version and exit
 
 The legacy environment variable overrides from the original proof of
 concept remain available.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,12 +6,39 @@
 #include <string>
 #include <vector>
 
+namespace {
+
+void print_help(const char *prog) {
+    std::cout << "Usage: " << prog << " [options] [output_directory]\n\n"
+              << "Options:\n"
+              << "  --fps <fps>               target frames per second\n"
+              << "  --shutter <microsec>      exposure time in microseconds\n"
+              << "  --gain <gain>             analogue gain\n"
+              << "  --ae <0|1>                disable auto-exposure if set to 1\n"
+              << "  --awb <0|1>               disable auto white balance if set to 1\n"
+              << "  --preview                 enable hardware preview stream\n"
+              << "  --preview-size WxH        preview dimensions\n"
+              << "  --preview-sink <sink>     preview sink (gl or kmssink)\n"
+              << "  --preview-every N         push every Nth preview frame\n"
+              << "  --size WxH                RAW stream size\n"
+              << "  --help, -h                display this help and exit\n"
+              << "  --version, -v             output version information and exit\n";
+}
+
+} // namespace
+
 int main(int argc, char **argv) {
     std::string outDir = "./frames";
 
     for (int i = 1; i < argc; ++i) {
         std::string arg = argv[i];
-        if (arg == "--fps" && i + 1 < argc) {
+        if (arg == "--help" || arg == "-h") {
+            print_help(argv[0]);
+            return 0;
+        } else if (arg == "--version" || arg == "-v") {
+            std::cout << "dng-recorder version " << DNG_RECORDER_VERSION << std::endl;
+            return 0;
+        } else if (arg == "--fps" && i + 1 < argc) {
             setenv("FPS", argv[++i], 1);
         } else if (arg == "--shutter" && i + 1 < argc) {
             setenv("EXP_US", argv[++i], 1);


### PR DESCRIPTION
## Summary
- expose `--help` and `--version` flags in the recorder
- document new flags and usage instructions
- define project version during build

## Testing
- `cmake -S . -B build` *(fails: libcamera package missing)*
- `cmake --build build` *(fails: no build files generated)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c5a9ceeda08327a38c2a64d5946287