### PR TITLE
Add DNG metadata for Resolve

### DIFF
--- a/src/raw_recorder.cpp
+++ b/src/raw_recorder.cpp
@@ -121,8 +121,8 @@ static bool write_dng16(const std::string &path,
                         uint32_t width,
                         uint32_t height,
                         const std::string &cfa,
-                        uint16_t /*blackLevel*/ = 0,
-                        uint32_t /*whiteLevel*/ = 0)
+                        uint16_t blackLevel = 0,
+                        uint32_t whiteLevel = 0)
 {
     TIFF *tif = TIFFOpen(path.c_str(), "w");
     if (!tif) { std::perror("TIFFOpen"); return false; }
@@ -148,6 +148,20 @@ static bool write_dng16(const std::string &path,
     uint16_t dim[2] = {2, 2};
     TIFFSetField(tif, TIFFTAG_CFAREPEATPATTERNDIM, dim);
     TIFFSetField(tif, TIFFTAG_CFAPATTERN, 4, patt);
+
+    uint8_t cfaColors[3] = {0, 1, 2};
+    TIFFSetField(tif, TIFFTAG_CFAPLANECOLOR, 3, cfaColors);
+    TIFFSetField(tif, TIFFTAG_CFALAYOUT, 1); // rectangular
+
+    uint16_t blDim[2] = {1, 1};
+    TIFFSetField(tif, TIFFTAG_BLACKLEVELREPEATDIM, blDim);
+    uint16_t bl = blackLevel;
+    TIFFSetField(tif, TIFFTAG_BLACKLEVEL, 1, &bl);
+    if (whiteLevel)
+        TIFFSetField(tif, TIFFTAG_WHITELEVEL, whiteLevel);
+
+    uint8_t dngVersion[4] = {1, 4, 0, 0};
+    TIFFSetField(tif, TIFFTAG_DNGVERSION, dngVersion);
 
     // One big strip → fewer syscalls
     TIFFSetField(tif, TIFFTAG_ROWSPERSTRIP, height);
@@ -260,7 +274,8 @@ static void init_image_pool(size_t poolN, uint32_t w, uint32_t h)
     }
 }
 
-static void writer_thread(std::string outDir, uint32_t w, uint32_t h, std::string cfa)
+static void writer_thread(std::string outDir, uint32_t w, uint32_t h,
+                          std::string cfa, uint16_t blackLevel, uint32_t whiteLevel)
 {
     for (;;) {
         std::pair<size_t, uint64_t> job;
@@ -282,7 +297,7 @@ static void writer_thread(std::string outDir, uint32_t w, uint32_t h, std::strin
         char name[256];
         std::snprintf(name, sizeof(name), "frame_%06llu.dng", (unsigned long long)idx);
         const std::string path = (std::filesystem::path(outDir) / name).string();
-        if (write_dng16(path, img.data(), w, h, cfa))
+        if (write_dng16(path, img.data(), w, h, cfa, blackLevel, whiteLevel))
             ++g_saved;
 
         // Return slot to pool
@@ -843,8 +858,12 @@ int run_raw_recorder(int argc, char **argv)
 
     cam->requestCompleted.connect(&on_request_completed);
 
+    uint16_t blackLevel = 0;
+    uint32_t whiteLevel = is16 ? 65535u : 4095u;
+
     // spin up writer thread
-    std::thread wt(writer_thread, ctx.outDir, sizeRaw.width, sizeRaw.height, cfa);
+    std::thread wt(writer_thread, ctx.outDir, sizeRaw.width, sizeRaw.height, cfa,
+                   blackLevel, whiteLevel);
 
 #ifndef NO_GST
     // Start preview pipeline before camera to reduce startup latency


### PR DESCRIPTION
## Summary
- write black/white level and CFA metadata into DNG frames
- thread passes white level based on pixel format to writer

## Testing
- `cmake ..` (fails: The following required packages were not found: libcamera)
- `apt-get update` (fails: repository is not signed)


------
https://chatgpt.com/codex/tasks/task_e_68c60c043710832782d1bb8aa072cc9a